### PR TITLE
Prevent User Heatmap from becoming very small in Gitea 1.18.1

### DIFF
--- a/theme-gitea-blue.css
+++ b/theme-gitea-blue.css
@@ -37663,7 +37663,7 @@ span.ui.massive.text {
   text-align: center;
   position: relative;
   min-height: 125px;
-  display: flex;
+  display: block;
   align-items: center;
   justify-content: center
 }


### PR DESCRIPTION
This aligns gitea-lightblue to the updated Gitea default CSS which now also uses `block `instead of `flex`.

Cf. e.g. https://try.gitea.io/

![image](https://user-images.githubusercontent.com/13728481/213193496-beaabb53-89f9-45ed-9199-2b4d86c034cb.png)
