### PR TITLE
adjust for 1.12.x

### DIFF
--- a/theme-gitea-blue.css
+++ b/theme-gitea-blue.css
@@ -2,11 +2,6 @@
   custom
 */
 
-#navbar .item {
-  color: var(--color-text-white);
-
-}
-
 #navbar .item:hover {
   background: var(--color-gitea-lightblue-light);
 }
@@ -39241,6 +39236,7 @@ body>div[id*=mermaid-] {
   --color-text-white: #ffffff;
   --color-nav-bg: var(--color-gitea-lightblue-dark);
   --color-nav-hover-bg: var(--color-gitea-lightblue-light);
+  --color-nav-text: var(--color-white);
   /* end of custom gitea-lightblue theme variables */
 }
 

--- a/theme-gitea-blue.css
+++ b/theme-gitea-blue.css
@@ -39239,7 +39239,8 @@ body>div[id*=mermaid-] {
   --color-gitea-lightblue-light: #296ca3;
   --color-gitea-lightblue-dark: #205081;
   --color-text-white: #ffffff;
-  --color-nav-bg: var(--color-gitea-lightblue-dark)
+  --color-nav-bg: var(--color-gitea-lightblue-dark);
+  --color-nav-hover-bg: var(--color-gitea-lightblue-light);
   /* end of custom gitea-lightblue theme variables */
 }
 

--- a/theme-gitea-blue.css
+++ b/theme-gitea-blue.css
@@ -37663,7 +37663,7 @@ span.ui.massive.text {
   text-align: center;
   position: relative;
   min-height: 125px;
-  display: flex;
+  display: block;
   align-items: center;
   justify-content: center
 }

--- a/theme-gitea-blue.css
+++ b/theme-gitea-blue.css
@@ -37663,7 +37663,7 @@ span.ui.massive.text {
   text-align: center;
   position: relative;
   min-height: 125px;
-  display: block;
+  display: flex;
   align-items: center;
   justify-content: center
 }
@@ -39239,6 +39239,7 @@ body>div[id*=mermaid-] {
   --color-gitea-lightblue-light: #296ca3;
   --color-gitea-lightblue-dark: #205081;
   --color-text-white: #ffffff;
+  --color-nav-bg: var(--color-gitea-lightblue-dark)
   /* end of custom gitea-lightblue theme variables */
 }
 


### PR DESCRIPTION
using specifically 1.12.7 I had to adjust the CSS to keep the navbar items white
I used the simple way by overwriting the navbar color instead of using custom css, as it seems to be the more clean solution